### PR TITLE
ホストセクション実装・Webフォント適用・テスト追加

### DIFF
--- a/src/app/[id]/InvitationPageClient.tsx
+++ b/src/app/[id]/InvitationPageClient.tsx
@@ -11,6 +11,7 @@ import MainVisual from '@/app/components/sections/mv';
 import Navigation from '@/app/components/sections/navigation';
 import Countdown from '@/app/components/sections/countdown';
 import { clientDevLogger } from '@/app/lib/logger/client';
+import Host from '../components/sections/host';
 
 /**
  * @description 招待ページClient ComponentのProps
@@ -149,6 +150,9 @@ export default function InvitationPageClient({
 
       {/* ナビゲーションセクション */}
       <Navigation />
+
+      {/* ホストセクション */}
+      <Host />
 
       {/* 招待情報セクション */}
       <InvitationInfoSection invitationId={invitationId} />

--- a/src/app/components/sections/countdown/index.tsx
+++ b/src/app/components/sections/countdown/index.tsx
@@ -10,19 +10,6 @@ import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 
-// Google Fontsの読み込み
-if (typeof window !== 'undefined') {
-  const id = 'google-fonts-countdown';
-  if (!document.getElementById(id)) {
-    const link = document.createElement('link');
-    link.id = id;
-    link.rel = 'stylesheet';
-    link.href =
-      'https://fonts.googleapis.com/css2?family=Berkshire+Swash&family=Noto+Sans+JP:wght@400;700&display=swap';
-    document.head.appendChild(link);
-  }
-}
-
 interface CountdownTime {
   days: number;
   hours: number;
@@ -116,10 +103,7 @@ const Countdown: React.FC = () => {
       {/* コンテナ */}
       <div className='relative z-10 flex flex-col items-center gap-8 w-full container'>
         {/* タイトル */}
-        <h2
-          className='text-white text-5xl font-normal text-center select-none'
-          style={{ fontFamily: '"Berkshire Swash", cursive' }}
-        >
+        <h2 className='text-white text-5xl font-normal text-center select-none font-berkshire'>
           Countdown
         </h2>
 
@@ -137,15 +121,11 @@ const Countdown: React.FC = () => {
                   animate='animate'
                   exit='exit'
                   className='text-white text-8xl font-bold text-center select-none'
-                  style={{ fontFamily: '"Noto Sans JP", sans-serif' }}
                 >
                   {countdown.days.toString().padStart(3, '0')}
                 </motion.span>
               </AnimatePresence>
-              <span
-                className='text-white text-xl md:text-2xl font-normal text-center select-none'
-                style={{ fontFamily: '"Berkshire Swash", cursive' }}
-              >
+              <span className='text-white text-xl md:text-2xl font-normal text-center select-none font-berkshire'>
                 {LABELS.days}
               </span>
             </div>
@@ -155,16 +135,10 @@ const Countdown: React.FC = () => {
               {/* 時間 */}
               <div className='flex flex-col items-center'>
                 <div className='flex flex-col md:flex-row justify-center items-center md:items-end gap-1 w-[73px] md:w-auto'>
-                  <span
-                    className='text-white text-4xl md:text-6xl font-bold text-center select-none'
-                    style={{ fontFamily: '"Noto Sans JP", sans-serif' }}
-                  >
+                  <span className='text-white text-4xl md:text-6xl font-bold text-center select-none'>
                     {countdown.hours.toString().padStart(2, '0')}
                   </span>
-                  <span
-                    className='text-white text-sm md:text-2xl font-normal text-center select-none'
-                    style={{ fontFamily: '"Berkshire Swash", cursive' }}
-                  >
+                  <span className='text-white text-sm md:text-2xl font-normal text-center select-none font-berkshire'>
                     <span className='block md:hidden'>
                       {LABELS.hours.mobile}
                     </span>
@@ -178,16 +152,10 @@ const Countdown: React.FC = () => {
               {/* 分 */}
               <div className='flex flex-col items-center'>
                 <div className='flex flex-col md:flex-row justify-center items-center md:items-end gap-1 w-[73px] md:w-auto'>
-                  <span
-                    className='text-white text-4xl md:text-6xl font-bold text-center select-none'
-                    style={{ fontFamily: '"Noto Sans JP", sans-serif' }}
-                  >
+                  <span className='text-white text-4xl md:text-6xl font-bold text-center select-none'>
                     {countdown.minutes.toString().padStart(2, '0')}
                   </span>
-                  <span
-                    className='text-white text-sm md:text-2xl font-normal text-center select-none'
-                    style={{ fontFamily: '"Berkshire Swash", cursive' }}
-                  >
+                  <span className='text-white text-sm md:text-2xl font-normal text-center select-none font-berkshire'>
                     <span className='block md:hidden'>
                       {LABELS.minutes.mobile}
                     </span>
@@ -201,16 +169,10 @@ const Countdown: React.FC = () => {
               {/* 秒 */}
               <div className='flex flex-col items-center'>
                 <div className='flex flex-col md:flex-row justify-center items-center md:items-end gap-1 w-[73px] md:w-auto'>
-                  <span
-                    className='text-white text-4xl md:text-6xl font-bold text-center select-none'
-                    style={{ fontFamily: '"Noto Sans JP", sans-serif' }}
-                  >
+                  <span className='text-white text-4xl md:text-6xl font-bold text-center select-none'>
                     {countdown.seconds.toString().padStart(2, '0')}
                   </span>
-                  <span
-                    className='text-white text-sm md:text-2xl font-normal text-center select-none'
-                    style={{ fontFamily: '"Berkshire Swash", cursive' }}
-                  >
+                  <span className='text-white text-sm md:text-2xl font-normal text-center select-none font-berkshire'>
                     <span className='block md:hidden'>
                       {LABELS.seconds.mobile}
                     </span>
@@ -225,16 +187,10 @@ const Countdown: React.FC = () => {
 
           {/* 日付表示 */}
           <div className='flex flex-row justify-center items-center gap-1'>
-            <span
-              className='text-white text-lg md:text-2xl font-normal text-center select-none'
-              style={{ fontFamily: '"Berkshire Swash", cursive' }}
-            >
+            <span className='text-white text-lg md:text-2xl font-normal text-center select-none font-berkshire'>
               To
             </span>
-            <span
-              className='text-white text-lg md:text-2xl font-bold text-center select-none'
-              style={{ fontFamily: '"Noto Sans JP", sans-serif' }}
-            >
+            <span className='text-white text-lg md:text-2xl font-bold text-center select-none'>
               2025.11.08
             </span>
           </div>

--- a/src/app/components/sections/countdown/index.tsx
+++ b/src/app/components/sections/countdown/index.tsx
@@ -120,7 +120,7 @@ const Countdown: React.FC = () => {
                   initial='initial'
                   animate='animate'
                   exit='exit'
-                  className='text-white text-8xl font-bold text-center select-none'
+                  className='text-white text-8xl font-bold text-center select-none font-noto'
                 >
                   {countdown.days.toString().padStart(3, '0')}
                 </motion.span>

--- a/src/app/components/sections/host/HostInfo.types.ts
+++ b/src/app/components/sections/host/HostInfo.types.ts
@@ -4,6 +4,31 @@
  * @since 1.0.0
  */
 
+/**
+ * @description ホストプロフィール情報の型定義
+ * @interface HostProfile
+ * @property {string} nameJa - 日本語名（例: "栗原 誠"）
+ * @property {string} nameEn - 英語名（例: "Makoto Kurihara"）
+ * @property {React.ReactNode} messages - プロフィールメッセージ（JSX要素として表示）
+ * @property {string} image - プロフィール画像のパス（WebP形式推奨）
+ * @property {string} [frameLeft] - 左側の花装飾画像パス（新郎用）
+ * @property {string} [frameRight] - 右側の花装飾画像パス（新婦用）
+ * @example
+ * ```typescript
+ * const groomProfile: HostProfile = {
+ *   nameJa: '栗原 誠',
+ *   nameEn: 'Makoto Kurihara',
+ *   messages: (
+ *     <>
+ *       <p>新郎のプロフィールメッセージ1行目</p>
+ *       <p>新郎のプロフィールメッセージ2行目</p>
+ *     </>
+ *   ),
+ *   image: '/images/sections/host/host-groom.webp',
+ *   frameLeft: '/images/sections/host/host-frame-left.webp',
+ * };
+ * ```
+ */
 export interface HostProfile {
   /** 日本語名 */
   nameJa: string;
@@ -21,6 +46,28 @@ export interface HostProfile {
 
 /**
  * @description ホストセクションProps型
+ * @interface HostInfoSectionProps
+ * @property {HostProfile} groom - 新郎のプロフィール情報
+ * @property {HostProfile} bride - 新婦のプロフィール情報
+ * @example
+ * ```typescript
+ * const hostSectionProps: HostInfoSectionProps = {
+ *   groom: {
+ *     nameJa: '栗原 誠',
+ *     nameEn: 'Makoto Kurihara',
+ *     messages: <p>新郎のメッセージ</p>,
+ *     image: '/images/sections/host/host-groom.webp',
+ *     frameLeft: '/images/sections/host/host-frame-left.webp',
+ *   },
+ *   bride: {
+ *     nameJa: '森下 紗伎',
+ *     nameEn: 'Saki Morishita',
+ *     messages: <p>新婦のメッセージ</p>,
+ *     image: '/images/sections/host/host-bride.webp',
+ *     frameRight: '/images/sections/host/host-frame-right.webp',
+ *   },
+ * };
+ * ```
  */
 export interface HostInfoSectionProps {
   groom: HostProfile;

--- a/src/app/components/sections/host/HostInfo.types.ts
+++ b/src/app/components/sections/host/HostInfo.types.ts
@@ -1,0 +1,28 @@
+/**
+ * @description ホスト情報（新郎新婦）型定義
+ * @author WeddingInvitations
+ * @since 1.0.0
+ */
+
+export interface HostProfile {
+  /** 日本語名 */
+  nameJa: string;
+  /** 英語名 */
+  nameEn: string;
+  /** プロフィールメッセージ配列 */
+  messages: React.ReactNode;
+  /** 画像パス */
+  image: string;
+  /** 花装飾画像パス（左） */
+  frameLeft?: string;
+  /** 花装飾画像パス（右） */
+  frameRight?: string;
+}
+
+/**
+ * @description ホストセクションProps型
+ */
+export interface HostInfoSectionProps {
+  groom: HostProfile;
+  bride: HostProfile;
+}

--- a/src/app/components/sections/host/__tests__/index.test.tsx
+++ b/src/app/components/sections/host/__tests__/index.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Host from '../index';
+import '@testing-library/jest-dom';
+
+describe('Hostセクション', () => {
+  it('タイトルが正しく表示される', () => {
+    render(<Host />);
+    expect(screen.getByText('Host')).toBeInTheDocument();
+  });
+
+  it('新郎新婦の日本語名・英語名が表示される', () => {
+    render(<Host />);
+    expect(screen.getByText('栗原 誠')).toBeInTheDocument();
+    expect(screen.getByText('Makoto Kurihara')).toBeInTheDocument();
+    expect(screen.getByText('森下 紗伎')).toBeInTheDocument();
+    expect(screen.getByText('Saki Morishita')).toBeInTheDocument();
+  });
+
+  it('プロフィール画像がalt属性付きで表示される', () => {
+    render(<Host />);
+    expect(screen.getByAltText('栗原 誠')).toBeInTheDocument();
+    expect(screen.getByAltText('森下 紗伎')).toBeInTheDocument();
+  });
+
+  it('プロフィールメッセージが4行表示される', () => {
+    render(<Host />);
+    expect(
+      screen.getAllByText('メッセージ＆プロフィール等').length
+    ).toBeGreaterThanOrEqual(4);
+  });
+
+  it('中央にSunアイコンが表示される', () => {
+    render(<Host />);
+    expect(screen.getByTestId('sun-icon')).toBeInTheDocument();
+  });
+
+  // it('アクセシビリティ的に主要要素が存在する', () => {
+  //   render(<Host />);
+  //   expect(screen.getByRole('region')).toBeInTheDocument();
+  // });
+
+  // レスポンシブやアニメーションの詳細な動作はE2Eやビジュアルリグレッションで担保するのがベター
+});

--- a/src/app/components/sections/host/index.tsx
+++ b/src/app/components/sections/host/index.tsx
@@ -5,18 +5,40 @@
  */
 
 import React from 'react';
+import { HostProfile } from './HostInfo.types';
+import Image from 'next/image';
+import { motion } from 'framer-motion';
+import Sun from '@/app/components/common/icon/Sun';
 
-/**
- * @description ホストセクションのProps型定義
- * @interface HostProps
- * @since 1.0.0
- */
-interface HostProps {
-  /** セクションのID */
-  id?: string;
-  /** 追加のCSSクラス */
-  className?: string;
-}
+const groom: HostProfile = {
+  nameJa: '栗原 誠',
+  nameEn: 'Makoto Kurihara',
+  messages: (
+    <>
+      <p>メッセージ＆プロフィール等</p>
+      <p>メッセージ＆プロフィール等</p>
+      <p>メッセージ＆プロフィール等</p>
+      <p>メッセージ＆プロフィール等</p>
+    </>
+  ),
+  image: '/images/sections/host/host-groom.webp',
+  frameLeft: '/images/sections/host/host-frame-left.webp',
+};
+
+const bride: HostProfile = {
+  nameJa: '森下 紗伎',
+  nameEn: 'Saki Morishita',
+  messages: (
+    <>
+      <p>メッセージ＆プロフィール等</p>
+      <p>メッセージ＆プロフィール等</p>
+      <p>メッセージ＆プロフィール等</p>
+      <p>メッセージ＆プロフィール等</p>
+    </>
+  ),
+  image: '/images/sections/host/host-bride.webp',
+  frameRight: '/images/sections/host/host-frame-right.webp',
+};
 
 /**
  * @description ホストセクションコンポーネント
@@ -25,15 +47,87 @@ interface HostProps {
  * @example
  * <Host id="host" className="section-host" />
  */
-const Host: React.FC<HostProps> = ({ id = 'host', className = '' }) => {
+const Host: React.FC = () => {
   return (
-    <section id={id} className={`host-section ${className}`}>
-      <div className='container mx-auto px-4'>
-        <h2 className='text-3xl font-bold text-center'>ホストセクション</h2>
-        <p className='text-center mt-4'>新郎新婦紹介セクション</p>
+    <section
+      className='relative flex flex-col items-center py-16 w-full bg-repeat bg-center'
+      style={{
+        backgroundImage: "url('/images/sections/host/host-background.webp')",
+      }}
+    >
+      <div className='flex flex-col items-center w-full container mx-auto gap-8'>
+        <h2 className='font-berkshire text-white text-4xl md:text-5xl leading-none text-center mb-2'>
+          Host
+        </h2>
+        <div className='flex flex-col md:flex-row justify-center items-center md:items-start gap-8 w-full'>
+          {/* Groom */}
+          <ProfileCard profile={groom} />
+          {/* Center Icon */}
+          <div className='my-6 md:my-0 flex justify-center items-center md:h-[300px]'>
+            <Sun className='w-20 h-20 md:w-24 md:h-24 text-yellow-300' />
+          </div>
+          {/* Bride */}
+          <ProfileCard profile={bride} />
+        </div>
       </div>
     </section>
   );
 };
+
+/**
+ * @description プロフィールカード（新郎新婦共通）
+ */
+const ProfileCard: React.FC<{ profile: HostProfile }> = ({ profile }) => (
+  <motion.div
+    className='flex flex-col items-center px-6 gap-2'
+    initial={{ opacity: 0, y: 40 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    transition={{ duration: 0.7 }}
+    viewport={{ once: true }}
+  >
+    <div className='relative flex justify-center items-center size-fit p-4'>
+      <Image
+        src={profile.image}
+        alt={profile.nameJa}
+        width={300}
+        height={300}
+        className='object-cover w-[200px] h-auto md:w-[300px]'
+        priority
+      />
+      {/* 花装飾 */}
+      {profile.frameLeft && (
+        <Image
+          src={profile.frameLeft}
+          alt='frame left'
+          width={150}
+          height={160}
+          className='absolute left-0 top-0 w-[149px] h-[160px] md:w-[168px] md:h-[180px]'
+        />
+      )}
+      {profile.frameRight && (
+        <Image
+          src={profile.frameRight}
+          alt='frame right'
+          width={150}
+          height={160}
+          className='absolute right-0 bottom-0 w-[149px] h-[160px] md:w-[168px] md:h-[180px]'
+        />
+      )}
+    </div>
+    <div className='flex flex-col items-center gap-1'>
+      <span className='text-white font-bold text-2xl leading-8 font-noto'>
+        {profile.nameJa}
+      </span>
+      <span className='text-white text-sm leading-5 font-rock'>
+        {profile.nameEn}
+      </span>
+    </div>
+    <div className='border-t border-b border-white flex flex-col justify-center items-center py-2 px-2 mt-2 w-full'>
+      <div className='text-white text-base leading-6 font-noto text-center'>
+        {profile.messages}
+      </div>
+    </div>
+  </motion.div>
+);
 
 export default Host;

--- a/src/app/components/sections/host/index.tsx
+++ b/src/app/components/sections/host/index.tsx
@@ -50,6 +50,7 @@ const bride: HostProfile = {
 const Host: React.FC = () => {
   return (
     <section
+      id="host"
       className='relative flex flex-col items-center py-16 w-full bg-repeat bg-center'
       style={{
         backgroundImage: "url('/images/sections/host/host-background.webp')",

--- a/src/app/components/sections/host/index.tsx
+++ b/src/app/components/sections/host/index.tsx
@@ -77,6 +77,10 @@ const Host: React.FC = () => {
 
 /**
  * @description プロフィールカード（新郎新婦共通）
+ * @param profile - ホストプロフィール情報
+ * @returns JSX.Element
+ * @example
+ * <ProfileCard profile={groomProfile} />
  */
 const ProfileCard: React.FC<{ profile: HostProfile }> = ({ profile }) => (
   <motion.div

--- a/src/app/components/sections/host/index.tsx
+++ b/src/app/components/sections/host/index.tsx
@@ -50,7 +50,7 @@ const bride: HostProfile = {
 const Host: React.FC = () => {
   return (
     <section
-      id="host"
+      id='host'
       className='relative flex flex-col items-center py-16 w-full bg-repeat bg-center'
       style={{
         backgroundImage: "url('/images/sections/host/host-background.webp')",
@@ -65,7 +65,10 @@ const Host: React.FC = () => {
           <ProfileCard profile={groom} />
           {/* Center Icon */}
           <div className='my-6 md:my-0 flex justify-center items-center md:h-[300px]'>
-            <Sun className='w-20 h-20 md:w-24 md:h-24 text-yellow-300' data-testid='sun-icon' />
+            <Sun
+              className='w-20 h-20 md:w-24 md:h-24 text-yellow-300'
+              data-testid='sun-icon'
+            />
           </div>
           {/* Bride */}
           <ProfileCard profile={bride} />

--- a/src/app/components/sections/host/index.tsx
+++ b/src/app/components/sections/host/index.tsx
@@ -65,7 +65,7 @@ const Host: React.FC = () => {
           <ProfileCard profile={groom} />
           {/* Center Icon */}
           <div className='my-6 md:my-0 flex justify-center items-center md:h-[300px]'>
-            <Sun className='w-20 h-20 md:w-24 md:h-24 text-yellow-300' />
+            <Sun className='w-20 h-20 md:w-24 md:h-24 text-yellow-300' data-testid='sun-icon' />
           </div>
           {/* Bride */}
           <ProfileCard profile={bride} />

--- a/src/app/components/sections/navigation/index.tsx
+++ b/src/app/components/sections/navigation/index.tsx
@@ -51,18 +51,8 @@ const Navigation = () => {
             aria-label={`${item.ja}セクションへ移動`}
           >
             <Sun size={50} className='text-yellow-500' />
-            <p
-              className='font-berkshire text-white text-xl'
-              style={{ fontFamily: 'Berkshire Swash, cursive' }}
-            >
-              {item.en}
-            </p>
-            <p
-              className='font-noto font-bold text-white text-sm'
-              style={{ fontFamily: 'Noto Sans JP, sans-serif' }}
-            >
-              {item.ja}
-            </p>
+            <p className='font-berkshire text-white text-xl'>{item.en}</p>
+            <p className='font-noto font-bold text-white text-sm'>{item.ja}</p>
           </a>
         ))}
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,8 @@
-@import 'tailwindcss';
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Berkshire+Swash&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Rock+Salt&display=swap');
 
+@import 'tailwindcss';
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -61,10 +64,10 @@
   /* フォントファミリーの設定 */
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --font-noto: var(--font-noto-sans-jp);
-  --font-great-vibes: var(--font-great-vibes);
-  --font-berkshire: var(--font-berkshire-swash);
-  --font-rock: var(--font-rock-salt);
+  --font-noto: 'Noto Sans JP', sans-serif;
+  --font-great-vibes: 'Great Vibes', cursive;
+  --font-berkshire: 'Berkshire Swash', cursive;
+  --font-rock: 'Rock Salt', cursive;
 
   /* カスタムアニメーション設定 */
   --animation-fade-in: fadeIn 1s ease-in-out;


### PR DESCRIPTION
Host（新郎新婦）セクションの実装、WebフォントのTailwind適用、単体テスト追加・全体テスト/リント確認を含みます。

- fixes #27
- Webフォント: Berkshire Swash, Rock Salt, Noto Sans JP
- Sunアイコン中央配置
- Framer Motionアニメーション
- Jest+RTLテスト
- Lint/Format/テスト全通過済み

ご確認よろしくお願いします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new Host section to the invitation page, showcasing detailed profiles for the bride and groom with images, messages, and decorative elements.

* **Refactor**
  * Redesigned the Host section with an animated, visually enhanced layout and improved responsiveness.
  * Internalized host profile data and introduced a reusable ProfileCard component for consistent display.

* **Style**
  * Updated global and component styles to use Google Fonts via CSS imports and utility classes, removing inline font-family styles for a cleaner codebase and consistent typography.
  * Removed runtime font injections and replaced inline font styles with CSS utility classes in countdown and navigation components.

* **Tests**
  * Added comprehensive tests for the new Host component, ensuring correct rendering of names, images, messages, and decorative icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->