### PR TITLE
feat: フッターセクションのデザイン準拠リファクタリングと招待ページへの設置 fixes #51

### DIFF
--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   RSVP, // 追加
   Footer, // 追加
 } from '../components/sections';
+import { getMicroCMSClient } from '@/app/lib/api/microcms';
 
 /**
  * @description 動的メタデータ生成
@@ -99,4 +100,16 @@ export default async function InvitationPage({
       <Footer />
     </div>
   );
+}
+
+// 静的パスを生成
+export async function generateStaticParams() {
+  const client = await getMicroCMSClient();
+  const data = await client.getAllContentIds({
+    endpoint: 'guests',
+  });
+
+  return data.map(contentId => ({
+    id: contentId,
+  }));
 }

--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   Gallery,
   Event,
   RSVP, // 追加
+  Footer, // 追加
 } from '../components/sections';
 
 /**
@@ -94,8 +95,8 @@ export default async function InvitationPage({
       {/* RSVPセクション */}
       <RSVP invitationId={invitationId} draftKey={draftKey} />
 
-      {/* ギャラリーセクション */}
-      {/* <GallerySection /> */}
+      {/* フッターセクション */}
+      <Footer />
     </div>
   );
 }

--- a/src/app/components/sections/footer/index.tsx
+++ b/src/app/components/sections/footer/index.tsx
@@ -5,34 +5,34 @@
  */
 
 import React from 'react';
+import Link from 'next/link';
 
 /**
- * @description フッターセクションのProps型定義
- * @interface FooterProps
- * @since 1.0.0
- */
-interface FooterProps {
-  /** セクションのID */
-  id?: string;
-  /** 追加のCSSクラス */
-  className?: string;
-}
-
-/**
- * @description フッターセクションコンポーネント
- * @param props - コンポーネントのProps
+ * @description フッターセクション（propsなし・Tailwind CSSのみでデザイン再現）
  * @returns JSX.Element
- * @example
- * <Footer id="footer" className="section-footer" />
+ * @example <Footer />
  */
-const Footer: React.FC<FooterProps> = ({ id = 'footer', className = '' }) => {
+const Footer: React.FC = () => {
   return (
-    <section id={id} className={`footer-section ${className}`}>
-      <div className='container mx-auto px-4'>
-        <h2 className='text-3xl font-bold text-center'>フッターセクション</h2>
-        <p className='text-center mt-4'>フッターセクション</p>
+    <footer className='flex flex-col items-center justify-center w-full bg-white'>
+      <div className='flex flex-col items-center justify-center py-8 gap-2'>
+        <span className='text-4xl font-bold text-center font-rock text-gray-900'>
+          Thank You !
+        </span>
       </div>
-    </section>
+      <div className='flex flex-col items-center justify-center w-full bg-lavender-600 py-1'>
+        <span className='text-xs text-center  text-white'>
+          © 2025{' '}
+          <Link
+            href='https://www.pitolick.com/'
+            target='_blank'
+            rel='noopener noreferrer'
+          >
+            ぴいてっく
+          </Link>
+        </span>
+      </div>
+    </footer>
   );
 };
 


### PR DESCRIPTION
フッターセクションのデザインを仕様通りにリファクタリングし、[id]ページに設置しました。\n- Tailwind CSSのみでデザイン再現\n- microCMS静的パス生成の型エラーも解消\n- タイピング風アニメーションは一旦保留\n\nご確認をお願いします。