### PR TITLE
feat: トップページアクセス拒否、404ページ作成、microCMS存在確認機能 fixes #43

### DIFF
--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -33,6 +33,7 @@ export async function generateMetadata({
   return {
     title: `Wedding Invitation - ${invitationId}`,
     description: `ディズニーテーマの特別な結婚式招待状です。招待ID: ${invitationId}`,
+    robots: 'noindex',
     keywords: [
       'wedding',
       'invitation',

--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import {
   MainVisual,
   Navigation,
@@ -70,6 +71,18 @@ export default async function InvitationPage({
   params: Promise<{ id: string; draftKey?: string }>;
 }) {
   const { id: invitationId, draftKey } = await params;
+
+  // microCMSからゲスト情報を取得して存在確認
+  try {
+    const client = await getMicroCMSClient();
+    await client.get({
+      endpoint: 'guests',
+      contentId: invitationId,
+    });
+  } catch {
+    // ゲストが存在しない場合は404エラーを返す
+    notFound();
+  }
 
   return (
     <div className='min-h-screen'>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,6 +50,7 @@ const rockSalt = Rock_Salt({
 export const metadata: Metadata = {
   title: '結婚式招待状',
   description: '美しい結婚式招待状のWebサイト',
+  robots: 'noindex',
 };
 
 export default function RootLayout({

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '404 - ページが見つかりません',
+  description: 'お探しのページが見つかりませんでした',
+  robots: 'noindex',
+};
+
+/**
+ * @description 404エラーページ（ディズニーテーマ）
+ * @returns JSX.Element
+ * @example <NotFound />
+ */
+export default function NotFound() {
+  return (
+    <div className='min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 flex items-center justify-center p-4'>
+      <div className='max-w-md w-full text-center'>
+        {/* 404アイコン */}
+        <div className='mb-8'>
+          <div className='text-8xl font-bold text-gray-400 mb-4'>404</div>
+          <div className='w-24 h-24 mx-auto mb-6'>
+            <svg
+              viewBox='0 0 24 24'
+              fill='none'
+              stroke='currentColor'
+              className='w-full h-full text-pink-500'
+              strokeWidth='1.5'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                d='M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z'
+              />
+            </svg>
+          </div>
+        </div>
+
+        {/* メッセージ */}
+        <h1 className='text-2xl font-bold text-gray-800 mb-4'>
+          お探しのページが見つかりません
+        </h1>
+        <div className='text-gray-600 space-y-4 mb-8'>
+          <p>
+            申し訳ございませんが、お探しのページは存在しないか、移動された可能性があります。
+          </p>
+          <p>招待状のURLをご確認ください</p>
+        </div>
+
+        {/* 装飾要素 */}
+        <div className='mt-12 opacity-30'>
+          <div className='flex justify-center space-x-2'>
+            {[...Array(3)].map((_, i) => (
+              <div
+                key={i}
+                className='w-2 h-2 bg-purple-400 rounded-full animate-pulse'
+                style={{ animationDelay: `${i * 0.2}s` }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,50 +1,29 @@
 import { Metadata } from 'next';
-import { HomeClient } from './components/HomeClient';
-import { Hr } from './components/common/decoration';
+import { notFound } from 'next/navigation';
 import { logger } from './lib/logger';
-import React from 'react';
 
 export const metadata: Metadata = {
-  title: '結婚式招待状 - 共通コンポーネントサンプル',
-  description:
-    '美しい結婚式招待状のWebサイト - 共通コンポーネントのサンプルページ',
+  title: '404 - ページが見つかりません',
+  description: 'ページが見つかりません',
+  robots: 'noindex',
 };
 
 /**
- * @description 結婚式招待状のメインページ（サーバーコンポーネント）
- * @returns メインページのJSX要素
+ * @description トップページは使用しないため、404エラーを返す
+ * @returns 404エラーページ
  */
 export default async function Page() {
-  // 初回アクセス時にログを記録
-  await logger.info('page_access', 'トップページにアクセス', {
+  // アクセス試行をログに記録
+  await logger.info('page_access_denied', 'トップページへのアクセスを拒否', {
     context: {
       timestamp: new Date().toISOString(),
       page: 'home',
+      action: 'not_found',
     },
-    humanNote: 'ユーザーがトップページにアクセス',
-    aiTodo: 'アクセス傾向を分析',
+    humanNote: 'トップページへのアクセスを404で拒否',
+    aiTodo: 'アクセス拒否の統計を記録',
   });
 
-  return (
-    <main className='min-h-screen p-8'>
-      <div className='max-w-4xl mx-auto space-y-8'>
-        <h1 className='text-4xl font-bold text-gray-900 mb-8'>
-          結婚式招待状 - 共通コンポーネントサンプル
-        </h1>
-
-        {/* Hrコンポーネント（デフォルト） */}
-        <Hr />
-        {/* Hrコンポーネント（カスタム例） */}
-        <Hr
-          width={800}
-          iconSize={24}
-          color='#73357a'
-          lineColor='#73357a'
-          className='my-8'
-        />
-
-        <HomeClient />
-      </div>
-    </main>
-  );
+  // 404エラーを返す
+  notFound();
 }


### PR DESCRIPTION
## 実装内容

### ✅ 完了した機能

1. **トップページアクセス拒否**
   - でを呼び出し
   - トップページ（）へのアクセスを404エラーで拒否
   - ログ記録機能付き

2. **404ページ作成**
   - で美しい404ページを実装
   - ディズニーテーマに合わせたデザイン
   - アニメーション効果付き
   - でSEO対策

3. **microCMS存在確認機能**
   - でmicroCMSからゲスト情報を取得
   - 存在しないIDでアクセスした場合に404エラーを返す
   - セキュリティとプライバシーの向上

### 🔍 動作確認
- トップページ（）→ 404ページ
- 存在しない招待ID（）→ 404ページ
- 有効な招待ID（）→ 正常に招待ページ表示

### 🛡️ セキュリティ向上
- 未登録の招待IDへのアクセスを完全にブロック
- 検索エンジンインデックスを無効化
- プライベートな結婚式招待状として適切な設定

ご確認をお願いします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a custom Disney-themed 404 error page with animated elements and clear messaging for missing or invalid pages.

* **Bug Fixes**
  * Improved handling of invalid invitation links by displaying a 404 error when guest data is not found.

* **Refactor**
  * The root page now triggers a 404 error instead of displaying the homepage content.

* **Documentation**
  * Updated page metadata across the site to include "noindex" directives, preventing search engines from indexing invitation and error pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->