### PR TITLE
feat: コンテンツ・フォーム・GAS調整 - 駐車場利用を代行利用に変更

### DIFF
--- a/scripts/google-apps-script/rsvp-handler.gs
+++ b/scripts/google-apps-script/rsvp-handler.gs
@@ -115,7 +115,7 @@ function validateData(data) {
     'birthday',
     'hotelUse',
     'taxiUse',
-    'parkingUse',
+    'daikoUse',
   ];
   for (let i = 0; i < data.attendees.length; i++) {
     const attendee = data.attendees[i];
@@ -178,7 +178,7 @@ function saveToSpreadsheet(data) {
       '誕生日',
       'ホテル利用',
       'タクシー利用',
-      '駐車場利用',
+      '代行利用',
       'アレルギー',
       '苦手な食べ物',
       '挙式出欠',
@@ -196,7 +196,7 @@ function saveToSpreadsheet(data) {
         attendee.birthday || '',
         attendee.hotelUse || '',
         attendee.taxiUse || '',
-        attendee.parkingUse || '',
+        attendee.daikoUse || '',
         JSON.stringify(attendee.allergies || []),
         attendee.dislikedFoods || '',
         attendee.ceremony || '',
@@ -276,7 +276,7 @@ function setupSpreadsheet() {
       '誕生日',
       'ホテル利用',
       'タクシー利用',
-      '駐車場利用',
+      '代行利用',
       'アレルギー',
       '苦手な食べ物',
       '挙式出欠',

--- a/scripts/google-apps-script/types.ts
+++ b/scripts/google-apps-script/types.ts
@@ -33,8 +33,8 @@ export interface Attendee {
   hotelUse: string;
   /** タクシー利用 */
   taxiUse: string;
-  /** 駐車場利用 */
-  parkingUse: string;
+  /** 代行利用 */
+  daikoUse: string;
   /** アレルギー情報 */
   allergies: string[];
   /** 苦手な食べ物 */
@@ -121,8 +121,8 @@ export interface RSVPAttendeeRow {
   hotelUse: string;
   /** タクシー利用 */
   taxiUse: string;
-  /** 駐車場利用 */
-  parkingUse: string;
+  /** 代行利用 */
+  daikoUse: string;
   /** アレルギー情報 (JSON文字列) */
   allergies: string;
   /** 苦手な食べ物 */

--- a/src/app/components/common/form/PostalCodeInput.tsx
+++ b/src/app/components/common/form/PostalCodeInput.tsx
@@ -92,14 +92,19 @@ const PostalCodeInput: React.FC<PostalCodeInputProps> = ({
       try {
         const response = await postalCodeApi.searchByPostalCode(postalCode);
 
-        if (response.addresses.length > 0) {
-          const address = response.addresses[0];
+        // APIレスポンスの構造を確認（createSuccessResponseでラップされている場合）
+        const data = response.data || response;
+
+        if (data && data.addresses && data.addresses.length > 0) {
+          const address = data.addresses[0];
           const fullAddress = `${address.pref_name}${address.city_name}${address.town_name}`;
 
           onAddressChange?.({
             prefecture: address.pref_name,
             address: fullAddress,
           });
+        } else {
+          setSearchError('該当する住所が見つかりませんでした');
         }
       } catch (error) {
         console.error('郵便番号検索エラー:', error);

--- a/src/app/components/sections/countdown/index.tsx
+++ b/src/app/components/sections/countdown/index.tsx
@@ -122,7 +122,7 @@ const Countdown: React.FC = () => {
                   exit='exit'
                   className='text-white text-8xl font-bold text-center select-none font-noto'
                 >
-                  {countdown.days.toString().padStart(3, '0')}
+                  {countdown.days.toString()}
                 </motion.span>
               </AnimatePresence>
               <span className='text-white text-xl md:text-2xl font-normal text-center select-none font-berkshire'>

--- a/src/app/components/sections/rsvp/RSVPClient.tsx
+++ b/src/app/components/sections/rsvp/RSVPClient.tsx
@@ -77,7 +77,7 @@ const attendeeSchema = z.object({
   birthday: z.string().min(1, '誕生日は必須です'),
   hotelUse: z.string().min(1, 'ホテル利用を選択してください'),
   taxiUse: z.string().min(1, 'タクシー利用を選択してください'),
-  parkingUse: z.string().min(1, '駐車場利用を選択してください'),
+  daikoUse: z.string().min(1, '代行利用を選択してください'),
   allergies: z.array(z.string()),
   dislikedFoods: z.string().optional(),
   ceremony: z.string().optional(), // 挙式の出欠（招待されている場合のみ）
@@ -133,7 +133,7 @@ type FilteredAttendeeType = Partial<AttendeeType> & {
   birthday: string;
   hotelUse: string;
   taxiUse: string;
-  parkingUse: string;
+  daikoUse: string;
   allergies: string[];
   dislikedFoods?: string;
 };
@@ -157,7 +157,7 @@ const defaultAttendee = (guestInfo?: GuestContent) => ({
   birthday: '',
   hotelUse: '',
   taxiUse: '',
-  parkingUse: '',
+  daikoUse: '',
   allergies: [],
   dislikedFoods: '',
   ceremony: undefined, // オプショナルフィールド
@@ -710,10 +710,10 @@ const RSVPClient: React.FC<RSVPClientProps> = ({ guestInfo }) => {
                 />
                 <Controller
                   control={form.control}
-                  name={`attendees.${index}.parkingUse`}
+                  name={`attendees.${index}.daikoUse`}
                   render={({ field }) => (
                     <Radio
-                      label='駐車場利用'
+                      label='代行利用'
                       required
                       options={[
                         { value: 'なし', label: 'なし' },
@@ -726,7 +726,7 @@ const RSVPClient: React.FC<RSVPClientProps> = ({ guestInfo }) => {
                       layout='horizontal'
                       value={field.value ?? ''}
                       onChange={field.onChange}
-                      error={errors.attendees?.[index]?.parkingUse?.message}
+                      error={errors.attendees?.[index]?.daikoUse?.message}
                     />
                   )}
                 />

--- a/src/app/components/sections/rsvp/types.ts
+++ b/src/app/components/sections/rsvp/types.ts
@@ -5,32 +5,81 @@
  */
 
 /**
+ * @description 連絡先情報の型定義
+ */
+export interface ContactInfo {
+  /** 郵便番号 */
+  postalCode: string;
+  /** 都道府県 */
+  prefecture: string;
+  /** 住所 */
+  address: string;
+  /** 電話番号 */
+  phone: string;
+  /** メールアドレス */
+  email: string;
+}
+
+/**
+ * @description 出席者情報の型定義
+ */
+export interface Attendee {
+  /** 出席者番号（microCMS IDまたは空文字） */
+  attendeeId?: string;
+  /** 出席者名 */
+  name: string;
+  /** ふりがな */
+  furigana: string;
+  /** 誕生日 */
+  birthday: string;
+  /** ホテル利用 */
+  hotelUse: string;
+  /** タクシー利用 */
+  taxiUse: string;
+  /** 代行利用 */
+  daikoUse: string;
+  /** アレルギー情報 */
+  allergies: string[];
+  /** 苦手な食べ物 */
+  dislikedFoods?: string;
+  /** 挙式出欠 */
+  ceremony?: string;
+  /** 披露宴出欠 */
+  reception?: string;
+  /** 二次会出欠 */
+  afterParty?: string;
+}
+
+/**
  * @description RSVPフォームデータの型定義
  * @example
  * ```typescript
  * const rsvpData: RSVPFormData = {
+ *   guestId: 'guest-123',
  *   name: '田中太郎',
- *   email: 'tanaka@example.com',
- *   attendance: 'attending',
- *   companions: 2,
- *   message: '楽しみにしています！',
- *   dietaryRestrictions: 'ベジタリアン'
+ *   contactInfo: {
+ *     postalCode: '1234567',
+ *     prefecture: '東京都',
+ *     address: '渋谷区...',
+ *     phone: '09012345678',
+ *     email: 'tanaka@example.com'
+ *   },
+ *   attendees: [...],
+ *   message: '楽しみにしています！'
  * };
  * ```
  */
 export interface RSVPFormData {
+  /** 招待者ID */
+  guestId: string;
   /** 招待者名 */
   name: string;
-  /** メールアドレス */
-  email: string;
-  /** 参加予定人数 */
-  attendance: 'attending' | 'declined';
-  /** 同伴者数 */
-  companions?: number;
+  /** 連絡先情報 */
+  contactInfo: ContactInfo;
+  /** 出席者情報 */
+  attendees: Attendee[];
   /** メッセージ */
   message?: string;
-  /** 食事制限 */
-  dietaryRestrictions?: string;
 }
 
 /**

--- a/src/app/lib/api/postal-code.ts
+++ b/src/app/lib/api/postal-code.ts
@@ -91,7 +91,14 @@ export class PostalCodeApiClient {
       throw new Error(`郵便番号検索エラー: ${errorData.error}`);
     }
 
-    return response.json();
+    const result = await response.json();
+
+    // createSuccessResponseでラップされている場合の処理
+    if (result.data) {
+      return result.data;
+    }
+
+    return result;
   }
 
   /**

--- a/src/app/lib/constants/events.tsx
+++ b/src/app/lib/constants/events.tsx
@@ -96,7 +96,7 @@ export const DEFAULT_EVENTS_DATA: EventData[] = [
         <br />
         お車で来てくださる方は
         <br />
-        会場前に00台停められる
+        会場前に80台停められる
         <br className='block lg:hidden' />
         駐車場がありますので
         <br />
@@ -168,7 +168,7 @@ export const DEFAULT_EVENTS_DATA: EventData[] = [
         <br />
         お車でお越しの場合は
         <br />
-        会場前に00台収容可能な駐車場が
+        会場前に80台収容可能な駐車場が
         <br />
         ございますのでご利用ください
       </p>


### PR DESCRIPTION
## 概要

フォーム項目の調整とTypeError修正を行いました。

## 変更内容

### 🔄 フォーム項目の調整
- **駐車場利用** → **代行利用** に変更
- RSVPフォームのzodスキーマ、型定義、UIコンポーネントを更新
- Google Apps Scriptの処理ロジックとスプレッドシート列名を更新

### 🛠️ TypeError修正
- **PostalCodeInput**コンポーネントのAPIレスポンス処理を安全に修正
- でラップされたレスポンス構造に対応
- null/undefinedチェックを追加して堅牢性を向上

### 📝 コンテンツテキストの調整
- カウントダウン表示のゼロパディングを削除
- 駐車場情報を「00台」→「80台」に修正

## 変更ファイル

### フォーム項目調整
- 
- 
- 
- 

### TypeError修正
- 
- 

### コンテンツ調整
- 
- 

## テスト結果
- ✅ Lint: 新規エラーなし
- ✅ テスト: 73 passed, 8 skipped (81 total)
- ✅ ビルド: 正常に完了
- ✅ 動作確認: 郵便番号入力機能が正常に動作

## 次のステップ
1. レビュー承認
2. Google Apps Scriptのデプロイ
3. 本番環境での動作確認