### PR TITLE
feat: ギャラリーUIの改善とオーバーレイ表示の最適化

### DIFF
--- a/src/app/components/sections/gallery/GalleryImage.tsx
+++ b/src/app/components/sections/gallery/GalleryImage.tsx
@@ -38,7 +38,7 @@ const GalleryImage: React.FC<GalleryImageProps> = ({
     <>
       <button
         type='button'
-        className='flex flex-col justify-center items-center size-full'
+        className='flex flex-col justify-center items-center size-full cursor-pointer'
         onClick={() => setIsOpen(true)}
         aria-label={alt}
       >

--- a/src/app/components/sections/gallery/index.tsx
+++ b/src/app/components/sections/gallery/index.tsx
@@ -3,8 +3,9 @@
  * @author WeddingInvitations
  * @since 1.0.0
  */
+'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import GalleryImage from './GalleryImage';
 
 /**
@@ -80,6 +81,12 @@ const galleryImages = [
  * <Gallery id="gallery" className="section-gallery" />
  */
 const Gallery: React.FC = () => {
+  const [isRevealed, setIsRevealed] = useState(false);
+
+  const handleReveal = () => {
+    setIsRevealed(true);
+  };
+
   return (
     <section
       id='gallery'
@@ -90,6 +97,45 @@ const Gallery: React.FC = () => {
       <div className='container m-auto'>
         <div className='flex flex-col items-center justify-center'>
           <div className='w-full grid grid-cols-3 grid-rows-4 gap-0 sm:grid-cols-4 md:grid-cols-6 sm:grid-rows-3 md:grid-rows-2 relative'>
+            {/* 初期状態のオーバーレイ */}
+            {!isRevealed && (
+              <div
+                className='absolute inset-0 z-20 bg-black/20 backdrop-blur-sm flex items-center justify-center cursor-pointer transition-all duration-500 hover:bg-black/50 group'
+                onClick={handleReveal}
+              >
+                <div className='text-center space-y-4 p-8'>
+                  {/* メインアイコン */}
+                  <div className='mx-auto w-20 h-20 bg-white rounded-full flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform duration-300'>
+                    <svg
+                      className='w-12 h-12 text-lavender-500'
+                      fill='none'
+                      stroke='currentColor'
+                      viewBox='0 0 24 24'
+                      xmlns='http://www.w3.org/2000/svg'
+                    >
+                      <path
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        strokeWidth={2}
+                        d='M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z'
+                      />
+                    </svg>
+                  </div>
+
+                  {/* メインテキスト */}
+                  <div className='space-y-2'>
+                    <h3 className='text-2xl md:text-3xl font-bold text-white font-berkshire'>
+                      Gallery
+                    </h3>
+                    <p className='text-sm text-white'>
+                      画像をクリックまたはタップして拡大表示
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* 画像グリッド */}
             {galleryImages.map(img => (
               <GalleryImage
                 key={img.image}


### PR DESCRIPTION
- ギャラリーセクション全体に薄い黒のオーバーレイ追加
- 初期状態で「Gallery」タイトルと操作説明を表示
- クリック/タップでオーバーレイが消えて画像を表示
- フェードインアニメーションを削除してシンプルな表示制御に変更
- レイアウト崩れを防止し、absolute配置でオーバーレイを実装

refs #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - ギャラリーに初回表示用オーバーレイを追加。中央のアイコンとタイトル・案内文を表示し、クリックでオーバーレイが消えてギャラリーが現れます。スムーズなトランジション付き。

- スタイル
  - ギャラリー画像のボタンにポインターカーソルを付与し、クリック可能性を明確化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->